### PR TITLE
fix: Resolve PDF generation error for lost time reports

### DIFF
--- a/src/pages/LostTimeTrackingPage.jsx
+++ b/src/pages/LostTimeTrackingPage.jsx
@@ -8,7 +8,7 @@ import DatePicker from 'react-datepicker';
 import "react-datepicker/dist/react-datepicker.css";
 import { format } from 'date-fns';
 import jsPDF from 'jspdf';
-import 'jspdf-autotable';
+import autoTable from 'jspdf-autotable';
 
 const LostTimeTrackingPage = () => {
     // Form state
@@ -132,7 +132,7 @@ const LostTimeTrackingPage = () => {
                 tableRows.push(entryData);
             });
 
-            doc.autoTable({
+            autoTable(doc, {
                 head: [tableColumn],
                 body: tableRows,
                 startY: startY,
@@ -140,7 +140,7 @@ const LostTimeTrackingPage = () => {
                 headStyles: { fillColor: [22, 160, 133] },
             });
 
-            startY = doc.autoTable.previous.finalY + 10; // Update startY for next table
+            startY = doc.lastAutoTable.finalY + 10; // Update startY for next table
         });
 
 


### PR DESCRIPTION
This commit fixes a bug where the PDF export for the Daily Lost Time Tracking System was failing with the error `se.autoTable is not a function`.

- fix(jspdf): Correct `jspdf-autotable` import and usage
  - The import statement for `jspdf-autotable` in `src/pages/LostTimeTrackingPage.jsx` has been changed to a direct import.
  - The `autoTable` function is now explicitly called with the `jsPDF` instance, ensuring the plugin is applied correctly.
  - This resolves the runtime error and allows the PDF to be generated successfully.