### PR TITLE
fix: Align date and time fields in forms

### DIFF
--- a/src/pages/LostTimeTrackingPage.jsx
+++ b/src/pages/LostTimeTrackingPage.jsx
@@ -203,23 +203,33 @@ const LostTimeTrackingPage = ({ user }) => {
                     <form onSubmit={handleSubmit}>
                         {/* Form fields remain the same */}
                         <div className="row">
-                        <div className="col-md-3 mb-3">
-                            <label className="form-label">Start Date</label>
-                            <DatePicker selected={startDate} onChange={date => setStartDate(date)} className="form-control" />
+                            <div className="col-md-6 border-end">
+                                <p className="mb-1 fw-bold">Start</p>
+                                <div className="row">
+                                    <div className="col-md-6 mb-3">
+                                        <label className="form-label">Date</label>
+                                        <DatePicker selected={startDate} onChange={date => setStartDate(date)} className="form-control" />
+                                    </div>
+                                    <div className="col-md-6 mb-3">
+                                        <label className="form-label">Time</label>
+                                        <DatePicker selected={startTime} onChange={date => setStartTime(date)} showTimeSelect showTimeSelectOnly timeIntervals={15} timeCaption="Time" dateFormat="h:mm aa" className="form-control" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="col-md-6">
+                                <p className="mb-1 fw-bold">End</p>
+                                <div className="row">
+                                    <div className="col-md-6 mb-3">
+                                        <label className="form-label">Date</label>
+                                        <DatePicker selected={endDate} onChange={date => setEndDate(date)} className="form-control" />
+                                    </div>
+                                    <div className="col-md-6 mb-3">
+                                        <label className="form-label">Time</label>
+                                        <DatePicker selected={endTime} onChange={date => setEndTime(date)} showTimeSelect showTimeSelectOnly timeIntervals={15} timeCaption="Time" dateFormat="h:mm aa" className="form-control" />
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div className="col-md-3 mb-3">
-                            <label className="form-label">Start Time</label>
-                            <DatePicker selected={startTime} onChange={date => setStartTime(date)} showTimeSelect showTimeSelectOnly timeIntervals={15} timeCaption="Time" dateFormat="h:mm aa" className="form-control" />
-                        </div>
-                        <div className="col-md-3 mb-3">
-                            <label className="form-label">End Date</label>
-                            <DatePicker selected={endDate} onChange={date => setEndDate(date)} className="form-control" />
-                        </div>
-                        <div className="col-md-3 mb-3">
-                            <label className="form-label">End Time</label>
-                            <DatePicker selected={endTime} onChange={date => setEndTime(date)} showTimeSelect showTimeSelectOnly timeIntervals={15} timeCaption="Time" dateFormat="h:mm aa" className="form-control" />
-                        </div>
-                    </div>
                     <div className="row">
                         <div className="col-md-6 mb-3">
                             <label className="form-label">Order Number</label>

--- a/src/pages/MachineBreakdownPage.jsx
+++ b/src/pages/MachineBreakdownPage.jsx
@@ -133,17 +133,19 @@ const MachineBreakdownPage = ({ user }) => {
                             </div>
                         </div>
                         <div className="row">
-                        <div className="col-md-4 mb-3">
+                            <div className="col-md-12 mb-3">
                                 <label className="form-label">Operator Name</label>
                                 <Select options={employees} value={selectedEmployee} onChange={setSelectedEmployee} isClearable />
                             </div>
-                        <div className="col-md-4 mb-3">
-                            <label className="form-label">Start Date & Time</label>
-                            <DatePicker selected={startDate} onChange={(date) => setStartDate(date)} showTimeSelect timeFormat="HH:mm" timeIntervals={15} dateFormat="MMMM d, yyyy h:mm aa" className="form-control" />
                         </div>
-                        <div className="col-md-4 mb-3">
-                            <label className="form-label">End Date & Time</label>
-                            <DatePicker selected={endDate} onChange={(date) => setEndDate(date)} showTimeSelect timeFormat="HH:mm" timeIntervals={15} dateFormat="MMMM d, yyyy h:mm aa" className="form-control" />
+                        <div className="row">
+                            <div className="col-md-6 mb-3">
+                                <label className="form-label">Start Date & Time</label>
+                                <DatePicker selected={startDate} onChange={(date) => setStartDate(date)} showTimeSelect timeFormat="HH:mm" timeIntervals={15} dateFormat="MMMM d, yyyy h:mm aa" className="form-control" />
+                            </div>
+                            <div className="col-md-6 mb-3">
+                                <label className="form-label">End Date & Time</label>
+                                <DatePicker selected={endDate} onChange={(date) => setEndDate(date)} showTimeSelect timeFormat="HH:mm" timeIntervals={15} dateFormat="MMMM d, yyyy h:mm aa" className="form-control" />
                             </div>
                         </div>
                         <button type="submit" className="btn btn-primary">Save Breakdown</button>


### PR DESCRIPTION
This commit improves the layout of the date and time input fields on both the 'Daily Lost Time Recording Form' and the 'Log New Machine Breakdown' page for better visual alignment and consistency.

- fix(ui): Restructure date/time fields in `LostTimeTrackingPage.jsx` to group them under 'Start' and 'End' headings.
- fix(ui): Adjust the grid layout in `MachineBreakdownPage.jsx` to place the 'Start Date & Time' and 'End Date & Time' fields side-by-side in their own row.