### PR TITLE
feat: Add machine breakdown and lost time reports

### DIFF
--- a/src/components/reports/LostTimeReport.jsx
+++ b/src/components/reports/LostTimeReport.jsx
@@ -1,0 +1,98 @@
+// src/components/reports/LostTimeReport.jsx
+import React, { useMemo, forwardRef, useRef, useImperativeHandle } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { differenceInMinutes } from 'date-fns';
+
+const LostTimeReport = forwardRef(({ lostTimeEntries }, ref) => {
+    const chartRef = useRef(null);
+
+    const processedData = useMemo(() => {
+        const lostTimeByReason = lostTimeEntries.reduce((acc, entry) => {
+            const reason = entry.lostTimeReason || 'Unknown Reason';
+            const duration = (entry.startTime && entry.endTime)
+                ? differenceInMinutes(entry.endTime, entry.startTime)
+                : 0;
+
+            acc[reason] = (acc[reason] || 0) + duration;
+            return acc;
+        }, {});
+
+        const sortedReasons = Object.entries(lostTimeByReason)
+            .sort(([, a], [, b]) => b - a);
+
+        const labels = sortedReasons.map(([reason]) => reason);
+        const data = sortedReasons.map(([, duration]) => duration);
+
+        const tableData = lostTimeEntries.map(entry => ({
+            reason: entry.lostTimeReason,
+            employee: entry.employeeName,
+            duration: (entry.startTime && entry.endTime) ? differenceInMinutes(entry.endTime, entry.startTime) : 0,
+        }));
+
+        return { labels, data, tableData, title: 'Lost Time by Reason' };
+    }, [lostTimeEntries]);
+
+    useImperativeHandle(ref, () => ({
+        chart: chartRef.current,
+        title: processedData.title,
+        tableData: processedData.tableData.map(d => [d.reason, d.employee, `${d.duration} mins`]),
+        headers: ["Reason", "Employee", "Duration (mins)"]
+    }));
+
+    const chartData = {
+        labels: processedData.labels,
+        datasets: [{ label: 'Total Minutes Lost', data: processedData.data, backgroundColor: 'rgba(255, 206, 86, 0.6)' }],
+    };
+
+    const options = {
+        responsive: true,
+        plugins: {
+            legend: { position: 'top' },
+            title: { display: true, text: processedData.title },
+        },
+        scales: { y: { beginAtZero: true } }
+    };
+
+    return (
+        <div className="col-md-6 mb-4">
+            <div className="card h-100">
+                <div className="card-header">
+                    <h5 className="card-title mb-0">{processedData.title}</h5>
+                </div>
+                <div className="card-body">
+                    <div className="mb-4">
+                        <Bar options={options} data={chartData} ref={chartRef} />
+                    </div>
+                    <div>
+                        <table className="table table-striped table-sm">
+                            <thead className="table-light">
+                                <tr>
+                                    <th>Reason</th>
+                                    <th>Employee</th>
+                                    <th className="text-end">Duration (mins)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {processedData.tableData.length > 0 ? (
+                                    processedData.tableData.map(({ reason, employee, duration }, index) => (
+                                        <tr key={index}>
+                                            <td>{reason}</td>
+                                            <td>{employee}</td>
+                                            <td className="text-end">{duration}</td>
+                                        </tr>
+                                    ))
+                                ) : (
+                                    <tr>
+                                        <td colSpan="3" className="text-center">No lost time entries in this period.</td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+});
+
+export default LostTimeReport;

--- a/src/components/reports/MachineBreakdownReport.jsx
+++ b/src/components/reports/MachineBreakdownReport.jsx
@@ -1,0 +1,94 @@
+// src/components/reports/MachineBreakdownReport.jsx
+import React, { useMemo, forwardRef, useRef, useImperativeHandle } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { differenceInMinutes } from 'date-fns';
+
+const MachineBreakdownReport = forwardRef(({ breakdowns }, ref) => {
+    const chartRef = useRef(null);
+
+    const processedData = useMemo(() => {
+        const breakdownsByMachine = breakdowns.reduce((acc, breakdown) => {
+            const machineName = breakdown.machineName || 'Unknown Machine';
+            acc[machineName] = (acc[machineName] || 0) + 1;
+            return acc;
+        }, {});
+
+        const sortedMachines = Object.entries(breakdownsByMachine)
+            .sort(([, a], [, b]) => b - a);
+
+        const labels = sortedMachines.map(([name]) => name);
+        const data = sortedMachines.map(([, count]) => count);
+
+        const tableData = breakdowns.map(b => ({
+            machine: b.machineName,
+            reason: b.reasonText,
+            duration: (b.startTime && b.endTime) ? differenceInMinutes(b.endTime, b.startTime) : 0,
+        }));
+
+        return { labels, data, tableData, title: 'Machine Breakdowns' };
+    }, [breakdowns]);
+
+    useImperativeHandle(ref, () => ({
+        chart: chartRef.current,
+        title: processedData.title,
+        tableData: processedData.tableData.map(d => [d.machine, d.reason, `${d.duration} mins`]),
+        headers: ["Machine", "Reason", "Duration"]
+    }));
+
+    const chartData = {
+        labels: processedData.labels,
+        datasets: [{ label: 'Number of Breakdowns', data: processedData.data, backgroundColor: 'rgba(153, 102, 255, 0.6)' }],
+    };
+
+    const options = {
+        responsive: true,
+        plugins: {
+            legend: { position: 'top' },
+            title: { display: true, text: 'Breakdowns by Machine' },
+        },
+        scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } }
+    };
+
+    return (
+        <div className="col-md-6 mb-4">
+            <div className="card h-100">
+                <div className="card-header">
+                    <h5 className="card-title mb-0">{processedData.title}</h5>
+                </div>
+                <div className="card-body">
+                    <div className="mb-4">
+                        <Bar options={options} data={chartData} ref={chartRef} />
+                    </div>
+                    <div>
+                        <table className="table table-striped table-sm">
+                            <thead className="table-light">
+                                <tr>
+                                    <th>Machine</th>
+                                    <th>Reason</th>
+                                    <th className="text-end">Duration (mins)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {processedData.tableData.length > 0 ? (
+                                    processedData.tableData.map(({ machine, reason, duration }, index) => (
+                                        <tr key={index}>
+                                            <td>{machine}</td>
+                                            <td>{reason}</td>
+                                            <td className="text-end">{duration}</td>
+                                        </tr>
+                                    ))
+                                ) : (
+                                    <tr>
+                                        <td colSpan="3" className="text-center">No breakdowns in this period.</td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+});
+
+export default MachineBreakdownReport;


### PR DESCRIPTION
This commit extends the comprehensive reporting feature by adding two new report sections:

- **Machine Breakdown Report:** Displays the number of breakdowns per machine and a detailed table with reasons and durations.
- **Lost Time Report:** Shows the total time lost for each reason with a corresponding data table.

Both new reports are integrated into the `Comprehensive Report` page, are filterable by the selected date range, and are included in the PDF export. The `ComprehensiveReport.jsx` component has been updated to fetch the necessary data from the `machineBreakdowns` and `lostTimeEntries` collections.