### PR TITLE
feat: Enhance Production Schedule Report

### DIFF
--- a/src/pages/ProductionScheduleReport.jsx
+++ b/src/pages/ProductionScheduleReport.jsx
@@ -1,86 +1,31 @@
-// src/pages/ReportsPage.jsx
+// src/pages/ProductionScheduleReport.jsx
 import React, { useState, useEffect, useMemo } from 'react';
 import { PDFDownloadLink, Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
 import { db } from '../firebase';
 import { collection, query, where, onSnapshot } from "firebase/firestore";
+import { getWeek } from 'date-fns';
 
 // --- PDF Document Component ---
-// This defines the structure and style of the PDF file.
 const SchedulePDFDocument = ({ ordersByCustomer, selectedWeek }) => {
     const styles = StyleSheet.create({
-        page: {
-            paddingTop: 35,
-            paddingBottom: 65,
-            paddingHorizontal: 30,
-            fontSize: 10,
-            fontFamily: 'Helvetica'
-        },
-        title: {
-            fontSize: 18,
-            textAlign: 'center',
-            marginBottom: 20,
-            fontFamily: 'Helvetica-Bold'
-        },
-        customerHeader: {
-            fontSize: 12,
-            backgroundColor: '#f0f0f0',
-            padding: 5,
-            marginTop: 10,
-            fontFamily: 'Helvetica-Bold'
-        },
-        table: {
-            display: 'table',
-            width: 'auto',
-            borderStyle: 'solid',
-            borderWidth: 1,
-            borderRightWidth: 0,
-            borderBottomWidth: 0
-        },
-        tableRow: {
-            flexDirection: 'row'
-        },
-        tableColHeader: {
-            width: '16.66%',
-            borderStyle: 'solid',
-            borderWidth: 1,
-            borderLeftWidth: 0,
-            borderTopWidth: 0,
-            backgroundColor: '#e0e0e0',
-            padding: 5,
-            fontFamily: 'Helvetica-Bold'
-        },
-        tableCol: {
-            width: '16.66%',
-            borderStyle: 'solid',
-            borderWidth: 1,
-            borderLeftWidth: 0,
-            borderTopWidth: 0,
-            padding: 5
-        },
-        descriptionCol: {
-             width: '33.32%',
-        },
-        footer: {
-            position: 'absolute',
-            bottom: 30,
-            left: 30,
-            right: 30,
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            fontSize: 9,
-            color: 'grey',
-        }
+        page: { paddingTop: 35, paddingBottom: 65, paddingHorizontal: 30, fontSize: 10, fontFamily: 'Helvetica' },
+        title: { fontSize: 18, textAlign: 'center', marginBottom: 20, fontFamily: 'Helvetica-Bold' },
+        customerHeader: { fontSize: 12, backgroundColor: '#f0f0f0', padding: 5, marginTop: 10, fontFamily: 'Helvetica-Bold' },
+        table: { display: 'table', width: 'auto', borderStyle: 'solid', borderWidth: 1, borderRightWidth: 0, borderBottomWidth: 0 },
+        tableRow: { flexDirection: 'row' },
+        tableColHeader: { width: '16.66%', borderStyle: 'solid', borderWidth: 1, borderLeftWidth: 0, borderTopWidth: 0, backgroundColor: '#e0e0e0', padding: 5, fontFamily: 'Helvetica-Bold' },
+        tableCol: { width: '16.66%', borderStyle: 'solid', borderWidth: 1, borderLeftWidth: 0, borderTopWidth: 0, padding: 5 },
+        descriptionCol: { width: '33.32%' },
+        footer: { position: 'absolute', bottom: 30, left: 30, right: 30, flexDirection: 'row', justifyContent: 'space-between', fontSize: 9, color: 'grey' }
     });
 
     const descriptionColStyle = {...styles.tableCol, ...styles.descriptionCol};
     const descriptionHeaderStyle = {...styles.tableColHeader, ...styles.descriptionCol};
 
-
     return (
         <Document>
             <Page style={styles.page} orientation="landscape">
                 <Text style={styles.title} fixed>{selectedWeek} - Yacht Sail Production Schedule</Text>
-
                 <View style={styles.table}>
                     <View style={styles.tableRow} fixed>
                         <Text style={styles.tableColHeader}>Aqua Order #</Text>
@@ -90,7 +35,6 @@ const SchedulePDFDocument = ({ ordersByCustomer, selectedWeek }) => {
                         <Text style={styles.tableColHeader}>Qty</Text>
                         <Text style={styles.tableColHeader}>Delivery Date</Text>
                     </View>
-
                     {Object.keys(ordersByCustomer).sort().map(customerName => (
                         <View key={customerName} break={false}>
                             <Text style={styles.customerHeader}>{customerName}</Text>
@@ -107,18 +51,14 @@ const SchedulePDFDocument = ({ ordersByCustomer, selectedWeek }) => {
                         </View>
                     ))}
                 </View>
-
                 <View style={styles.footer} fixed>
                     <Text>Prepared By Chamal Madushanke</Text>
-                    <Text render={({ pageNumber, totalPages }) => (
-                        `Page ${pageNumber} of ${totalPages}`
-                    )} />
+                    <Text render={({ pageNumber, totalPages }) => (`Page ${pageNumber} of ${totalPages}`)} />
                 </View>
             </Page>
         </Document>
     );
 };
-
 
 // --- Main Production Schedule Report Page Component ---
 const ProductionScheduleReport = () => {
@@ -133,20 +73,27 @@ const ProductionScheduleReport = () => {
             const ordersData = snap.docs.map(d => ({ id: d.id, ...d.data() }));
             setAllOrders(ordersData);
 
-            const weeks = [...new Set(ordersData.map(o => o.deliveryWeek).filter(Boolean))];
-            weeks.sort();
+            const weeks = [...new Set(ordersData.map(o => o.deliveryWeek).filter(Boolean))].sort();
             setDeliveryWeeks(weeks);
+
+            // Calculate current week and set it as default if it exists in the list
+            const currentYear = new Date().getFullYear();
+            const currentWeekNumber = getWeek(new Date(), { weekStartsOn: 1 }); // ISO 8601 week number
+            const currentWeekId = `${currentYear}-W${String(currentWeekNumber).padStart(2, '0')}`;
+
+            if (weeks.includes(currentWeekId)) {
+                setSelectedWeek(currentWeekId);
+            }
+
             setIsLoading(false);
         });
 
         return () => unsubscribe();
     }, []);
 
-    const ordersForPdf = useMemo(() => {
+    const ordersByCustomer = useMemo(() => {
         if (!selectedWeek) return {};
-
         const weekOrders = allOrders.filter(o => o.deliveryWeek === selectedWeek);
-
         return weekOrders.reduce((acc, order) => {
             const customer = order.customerCompanyName || 'Unknown Customer';
             if (!acc[customer]) acc[customer] = [];
@@ -156,41 +103,100 @@ const ProductionScheduleReport = () => {
     }, [selectedWeek, allOrders]);
 
     return (
-        <div className="row justify-content-center">
-            <div className="col-lg-6">
-                <div className="card">
-                    <div className="card-header">
-                        <h2 className="h4 mb-0">Generate Production Schedule Report</h2>
-                    </div>
-                    <div className="card-body text-center">
-                        <p className="card-text text-muted">
-                            Select a delivery week to generate and download the production schedule as a PDF file.
-                        </p>
-                        <div className="my-4">
-                            <label htmlFor="week-select" className="form-label fw-bold">Delivery Week</label>
-                            <select
-                                id="week-select"
-                                className="form-select form-select-lg"
-                                value={selectedWeek}
-                                onChange={(e) => setSelectedWeek(e.target.value)}
-                                disabled={isLoading}
-                            >
-                                <option value="">{isLoading ? "Loading weeks..." : "Choose a week..."}</option>
-                                {deliveryWeeks.map(week => <option key={week} value={week}>{week}</option>)}
-                            </select>
+        <div className="container-fluid">
+            <div className="row justify-content-center">
+                <div className="col-lg-8">
+                    <div className="card">
+                        <div className="card-header">
+                            <h2 className="h4 mb-0">Production Schedule Report</h2>
                         </div>
+                        <div className="card-body text-center">
+                            <p className="card-text text-muted">
+                                Select a delivery week to view the schedule or download it as a PDF.
+                            </p>
+                            <div className="my-4">
+                                <label htmlFor="week-select" className="form-label fw-bold">Delivery Week</label>
+                                <select
+                                    id="week-select"
+                                    className="form-select form-select-lg"
+                                    value={selectedWeek}
+                                    onChange={(e) => setSelectedWeek(e.target.value)}
+                                    disabled={isLoading}
+                                >
+                                    <option value="">{isLoading ? "Loading weeks..." : "Choose a week..."}</option>
+                                    {deliveryWeeks.map(week => <option key={week} value={week}>{week}</option>)}
+                                </select>
+                            </div>
 
-                        <PDFDownloadLink
-                            document={<SchedulePDFDocument ordersByCustomer={ordersForPdf} selectedWeek={selectedWeek} />}
-                            fileName={selectedWeek ? `production_schedule_${selectedWeek}.pdf` : 'production_schedule.pdf'}
-                            className={`btn btn-primary btn-lg ${!selectedWeek ? 'disabled' : ''}`}
-                            style={!selectedWeek ? { pointerEvents: 'none' } : {}}
-                        >
-                            {({ loading }) => (loading ? 'Generating PDF...' : 'Export to PDF')}
-                        </PDFDownloadLink>
+                            <PDFDownloadLink
+                                document={<SchedulePDFDocument ordersByCustomer={ordersByCustomer} selectedWeek={selectedWeek} />}
+                                fileName={selectedWeek ? `production_schedule_${selectedWeek}.pdf` : 'production_schedule.pdf'}
+                                className={`btn btn-primary btn-lg ${!selectedWeek ? 'disabled' : ''}`}
+                                style={!selectedWeek ? { pointerEvents: 'none' } : {}}
+                            >
+                                {({ loading }) => (loading ? 'Generating PDF...' : 'Export to PDF')}
+                            </PDFDownloadLink>
+                        </div>
                     </div>
                 </div>
             </div>
+
+            {selectedWeek && Object.keys(ordersByCustomer).length > 0 && (
+                <div className="row mt-4">
+                    <div className="col-12">
+                        <div className="card">
+                            <div className="card-header">
+                                <h3 className="h5 mb-0">Production Schedule for {selectedWeek}</h3>
+                            </div>
+                            <div className="card-body">
+                                <div className="table-responsive">
+                                    <table className="table table-bordered table-striped">
+                                        <thead className="table-light">
+                                            <tr>
+                                                <th>Aqua Order #</th>
+                                                <th>Customer PO</th>
+                                                <th>IFS Order #</th>
+                                                <th>Order Description</th>
+                                                <th>Qty</th>
+                                                <th>Delivery Date</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {Object.keys(ordersByCustomer).sort().map(customerName => (
+                                                <React.Fragment key={customerName}>
+                                                    <tr className="table-secondary">
+                                                        <td colSpan="6" className="fw-bold">{customerName}</td>
+                                                    </tr>
+                                                    {ordersByCustomer[customerName].map(order => (
+                                                        <tr key={order.id}>
+                                                            <td>{order.aquaOrderNumber || ''}</td>
+                                                            <td>{order.customerPO || ''}</td>
+                                                            <td>{order.ifsOrderNo || ''}</td>
+                                                            <td>{`${order.productName || ''} - ${order.material || ''} - ${order.size || ''}`}</td>
+                                                            <td>{order.quantity || ''}</td>
+                                                            <td>{order.deliveryDate || ''}</td>
+                                                        </tr>
+                                                    ))}
+                                                </React.Fragment>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {selectedWeek && Object.keys(ordersByCustomer).length === 0 && !isLoading && (
+                 <div className="row mt-4">
+                    <div className="col-12">
+                        <div className="card card-body text-center">
+                            <p className="mb-0 text-muted">No orders found for the selected week.</p>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
This commit improves the Production Schedule Report page by:

- **Defaulting to Current Week:** The page now automatically calculates the current week and sets it as the default selection on load, provided that data for the current week exists.
- **Displaying Schedule On-Page:** The production schedule is now displayed as a table directly on the page for the selected week. This allows for quick viewing without needing to download the PDF.
- **Maintaining PDF Export:** The "Export to PDF" functionality remains, allowing users to download a PDF version of the selected week's schedule.

These changes make the Production Schedule Report more user-friendly and provide immediate visibility of the relevant data.