### PR TITLE
feat: Add Ship Quantity to orders

### DIFF
--- a/src/components/production/AllActiveOrdersView.jsx
+++ b/src/components/production/AllActiveOrdersView.jsx
@@ -64,6 +64,16 @@ const AllActiveOrdersView = ({ user }) => {
         });
     };
 
+    const handleShipQtyChange = async (orderId, newShipQty) => {
+        if(isCustomer) return;
+        const qty = Number(newShipQty);
+        if (isNaN(qty) || qty < 0) {
+            toast.error("Invalid quantity");
+            return;
+        }
+        await updateDoc(doc(db, "orders", orderId), { shipQty: qty });
+    };
+
     const updateOrderStatus = async (order, newStatusId, reason = null) => {
         const newStatus = PRODUCTION_STATUSES.find(s => s.id === newStatusId);
         if (!newStatus) return;
@@ -155,14 +165,15 @@ const AllActiveOrdersView = ({ user }) => {
                             <th>Customer PO</th>
                             <th>IFS Order #</th>
                             <th>Order Description</th>
-                            <th>Qty</th>
+                            <th>PO Qty</th>
+                            <th>Ship Qty</th>
                             <th style={{width: '150px'}}>Delivery Date</th>
                             <th style={{width: '200px'}}>Production Status</th>
                         </tr>
                     </thead>
                     {Object.keys(groupedAndFilteredOrders).sort().map(customerName => (
                         <tbody key={customerName}>
-                            <tr className="table-light"><th colSpan="7" className="ps-2">{customerName}</th></tr>
+                            <tr className="table-light"><th colSpan="8" className="ps-2">{customerName}</th></tr>
                             {groupedAndFilteredOrders[customerName].map(order => (
                                 <tr key={order.id}>
                                     <td>
@@ -174,6 +185,15 @@ const AllActiveOrdersView = ({ user }) => {
                                     <td>{order.ifsOrderNo}</td>
                                     <td>{`${order.productName} - ${order.material} - ${order.size}`}</td>
                                     <td>{order.quantity}</td>
+                                    <td>
+                                        <input
+                                            type="number"
+                                            className="form-control form-control-sm"
+                                            defaultValue={order.shipQty ?? order.quantity}
+                                            onBlur={(e) => handleShipQtyChange(order.id, e.target.value)}
+                                            disabled={isCustomer}
+                                        />
+                                    </td>
                                     <td>
                                         <DatePicker
                                             selected={order.deliveryDate ? new Date(order.deliveryDate.replace(/-/g, '/')) : null}

--- a/src/components/production/WeeklyScheduleView.jsx
+++ b/src/components/production/WeeklyScheduleView.jsx
@@ -159,7 +159,7 @@ const WeeklyScheduleView = ({ user }) => {
                                     <th>Customer PO</th>
                                     <th>IFS Order #</th>
                                     <th>Order Description</th>
-                                    <th>Qty</th>
+                                    <th>Ship Qty</th>
                                     <th>Delivery Date</th>
                                     <th style={{width: '200px'}}>Production Status</th>
                                 </tr>
@@ -179,7 +179,7 @@ const WeeklyScheduleView = ({ user }) => {
                                             <td>{order.customerPO}</td>
                                             <td>{order.ifsOrderNo}</td>
                                             <td>{`${order.productName} - ${order.material} - ${order.size}`}</td>
-                                            <td>{order.quantity}</td>
+                                            <td>{order.shipQty ?? order.quantity}</td>
                                             <td>{order.deliveryDate}</td>
                                             <td>
                                                 <select 
@@ -207,8 +207,8 @@ const WeeklyScheduleView = ({ user }) => {
                             <div id="shipped-orders-collapse" className="accordion-collapse collapse">
                                 <div className="accordion-body p-0">
                                      <div className="table-responsive"><table className="table table-sm table-hover mb-0">
-                                        <thead><tr><th>Aqua Order #</th><th>Customer PO</th><th>Customer</th><th>Order Description</th><th>Qty</th><th>Delivery Date</th></tr></thead>
-                                        <tbody>{shippedOrders.map(order => <tr key={order.id} className="table-success"><td>{order.aquaOrderNumber}</td><td>{order.customerPO}</td><td>{order.customerCompanyName}</td><td>{`${order.productName} - ${order.material} - ${order.size}`}</td><td>{order.quantity}</td><td>{order.deliveryDate}</td></tr>)}</tbody>
+                                        <thead><tr><th>Aqua Order #</th><th>Customer PO</th><th>Customer</th><th>Order Description</th><th>Ship Qty</th><th>Delivery Date</th></tr></thead>
+                                        <tbody>{shippedOrders.map(order => <tr key={order.id} className="table-success"><td>{order.aquaOrderNumber}</td><td>{order.customerPO}</td><td>{order.customerCompanyName}</td><td>{`${order.productName} - ${order.material} - ${order.size}`}</td><td>{order.shipQty ?? order.quantity}</td><td>{order.deliveryDate}</td></tr>)}</tbody>
                                     </table></div>
                                 </div>
                             </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -113,7 +113,7 @@ const Dashboard = ({ user }) => {
                                                 <td>{order.customerPO}</td>
                                                 <td>{order.productName}</td>
                                                 <td>{order.quantity}</td>
-                                                <td>{order.shipQty ?? 'N/A'}</td>
+                                                <td>{order.shipQty ?? order.quantity}</td>
                                                 <td><span className={`badge ${getStatusBadgeClass(order.status)}`}>{order.status}</span></td>
                                             </tr>
                                         ))}
@@ -122,7 +122,7 @@ const Dashboard = ({ user }) => {
                                     Object.keys(ordersByCustomer).sort().map(customerName => (
                                         <tbody key={customerName}>
                                             <tr className="table-light">
-                                                <th colSpan="5" className="ps-2">{customerName}</th>
+                                                <th colSpan="6" className="ps-2">{customerName}</th>
                                             </tr>
                                             {ordersByCustomer[customerName].map(order => (
                                                 <tr key={order.id}>
@@ -130,7 +130,7 @@ const Dashboard = ({ user }) => {
                                                     <td>{order.customerPO}</td>
                                                     <td>{order.productName}</td>
                                                     <td>{order.quantity}</td>
-                                                    <td>{order.shipQty ?? 'N/A'}</td>
+                                                    <td>{order.shipQty ?? order.quantity}</td>
                                                     <td><span className={`badge ${getStatusBadgeClass(order.status)}`}>{order.status}</span></td>
                                                 </tr>
                                             ))}

--- a/src/pages/NewOrderForm.jsx
+++ b/src/pages/NewOrderForm.jsx
@@ -92,6 +92,7 @@ const NewOrderForm = ({ user, onOrderCreated, lastGeneratedOrderNumber }) => {
             customerPO,
             size,
             quantity: Number(quantity),
+            shipQty: Number(quantity),
             isIHC: isSailTypeSelected ? isIHC : false
         };
         


### PR DESCRIPTION
Adds a new `shipQty` field to orders to track a separate shipment quantity.

- The `shipQty` is initialized with the `quantity` from the purchase order.
- The "All Active Orders" page is updated to display "PO Qty" and a new editable "Ship Qty" column for non-customer users.
- The "Weekly Schedule" and "Dashboard" pages now display the `shipQty` instead of the original `quantity`.