### PR TITLE
fix(reports): Correct data filtering in report components

### DIFF
--- a/src/components/reports/MonthlyMaterialUsageAccessories.jsx
+++ b/src/components/reports/MonthlyMaterialUsageAccessories.jsx
@@ -8,7 +8,7 @@ const MonthlyMaterialUsageAccessories = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const materialUsage = orders
-            .filter(order => order.productType === 'Accessory' && order.material)
+            .filter(order => order.orderTypeName === 'Accessory' && order.material)
             .reduce((acc, order) => {
                 const month = format(order.orderDate, 'yyyy-MM');
                 const material = order.material.trim();

--- a/src/components/reports/MonthlyMaterialUsageSails.jsx
+++ b/src/components/reports/MonthlyMaterialUsageSails.jsx
@@ -8,7 +8,7 @@ const MonthlyMaterialUsageSails = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const materialUsage = orders
-            .filter(order => order.productType === 'Sail' && order.material)
+            .filter(order => order.orderTypeName === 'Sail' && order.material)
             .reduce((acc, order) => {
                 const month = format(order.orderDate, 'yyyy-MM');
                 const material = order.material.trim();

--- a/src/components/reports/MonthlyOrdersAccessories.jsx
+++ b/src/components/reports/MonthlyOrdersAccessories.jsx
@@ -8,7 +8,7 @@ const MonthlyOrdersAccessories = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const monthlyAccessories = orders
-            .filter(order => order.productType === 'Accessory')
+            .filter(order => order.orderTypeName === 'Accessory')
             .reduce((acc, order) => {
                 const month = format(order.orderDate, 'yyyy-MM');
                 const quantity = Number(order.quantity) || 0;

--- a/src/components/reports/MonthlyOrdersSails.jsx
+++ b/src/components/reports/MonthlyOrdersSails.jsx
@@ -8,7 +8,7 @@ const MonthlyOrdersSails = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const monthlySails = orders
-            .filter(order => order.productType === 'Sail')
+            .filter(order => order.orderTypeName === 'Sail')
             .reduce((acc, order) => {
                 const month = format(order.orderDate, 'yyyy-MM');
                 const quantity = Number(order.quantity) || 0;

--- a/src/components/reports/ProductTypeAnalysisAccessories.jsx
+++ b/src/components/reports/ProductTypeAnalysisAccessories.jsx
@@ -7,7 +7,7 @@ const ProductTypeAnalysisAccessories = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const productQuantities = orders
-            .filter(order => order.productType === 'Accessory')
+            .filter(order => order.orderTypeName === 'Accessory')
             .reduce((acc, order) => {
                 const productName = order.productName || 'Unknown Product';
                 const quantity = Number(order.quantity) || 0;

--- a/src/components/reports/ProductTypeAnalysisSails.jsx
+++ b/src/components/reports/ProductTypeAnalysisSails.jsx
@@ -7,7 +7,7 @@ const ProductTypeAnalysisSails = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const productQuantities = orders
-            .filter(order => order.productType === 'Sail')
+            .filter(order => order.orderTypeName === 'Sail')
             .reduce((acc, order) => {
                 const productName = order.productName || 'Unknown Product';
                 const quantity = Number(order.quantity) || 0;

--- a/src/components/reports/SalesByCustomerAccessories.jsx
+++ b/src/components/reports/SalesByCustomerAccessories.jsx
@@ -7,7 +7,7 @@ const SalesByCustomerAccessories = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const salesByCustomer = orders
-            .filter(order => order.productType === 'Accessory')
+            .filter(order => order.orderTypeName === 'Accessory')
             .reduce((acc, order) => {
                 const customerName = order.customerCompanyName || 'Unknown Customer';
                 const quantity = Number(order.quantity) || 0;

--- a/src/components/reports/SalesByCustomerSails.jsx
+++ b/src/components/reports/SalesByCustomerSails.jsx
@@ -6,7 +6,7 @@ const SalesByCustomerSails = forwardRef(({ orders }, ref) => {
 
     const processedData = useMemo(() => {
         const salesByCustomer = orders
-            .filter(order => order.productType === 'Sail')
+            .filter(order => order.orderTypeName === 'Sail')
             .reduce((acc, order) => {
                 const customerName = order.customerCompanyName || 'Unknown Customer';
                 const quantity = Number(order.quantity) || 0;


### PR DESCRIPTION
The comprehensive report section was not displaying data for the first eight reports because the filtering logic was using an incorrect field name. The report components were filtering by `productType`, but the actual field in the Firestore `orders` collection is `orderTypeName`.

This commit updates the following eight report components to use the correct `orderTypeName` field for filtering, ensuring that the reports now display the correct data:

-   `SalesByCustomerSails.jsx`
-   `MonthlyOrdersSails.jsx`
-   `MonthlyMaterialUsageSails.jsx`
-   `ProductTypeAnalysisSails.jsx`
-   `SalesByCustomerAccessories.jsx`
-   `MonthlyOrdersAccessories.jsx`
-   `MonthlyMaterialUsageAccessories.jsx`
-   `ProductTypeAnalysisAccessories.jsx`