### PR TITLE
Fix: Filter out shipped orders from the delivery week dropdown

### DIFF
--- a/src/pages/ProductionScheduleReport.jsx
+++ b/src/pages/ProductionScheduleReport.jsx
@@ -94,7 +94,9 @@ const ProductionScheduleReport = () => {
         const unsubscribe = onSnapshot(ordersQuery, (snap) => {
             const ordersData = snap.docs.map(d => ({ id: d.id, ...d.data() }));
             setAllOrders(ordersData);
-            const weeks = [...new Set(ordersData.map(o => o.deliveryWeek).filter(Boolean))];
+            // Filter out shipped orders before generating the list of weeks
+            const nonShippedOrders = ordersData.filter(o => o.status?.toLowerCase() !== 'shipped');
+            const weeks = [...new Set(nonShippedOrders.map(o => o.deliveryWeek).filter(Boolean))];
             weeks.sort();
             setDeliveryWeeks(weeks);
             setIsLoading(false);


### PR DESCRIPTION
The "Delivery week" dropdown in the Production Schedule Report was populated with weeks from all non-cancelled orders, including those that had already been shipped. This could lead to an empty report being displayed when a week with only shipped orders was selected.

This commit fixes the issue by filtering out shipped orders before populating the dropdown. This ensures that the dropdown only contains weeks with orders that are yet to be shipped, providing a more accurate and user-friendly experience.