### PR TITLE
feat: Relocate Production Schedule Report to Weekly Schedule

### DIFF
--- a/src/components/production/WeeklyScheduleView.jsx
+++ b/src/components/production/WeeklyScheduleView.jsx
@@ -19,7 +19,7 @@ const getCurrentWeek = () => {
     return `${year}-${String(week).padStart(2, '0')}`;
 };
 
-const WeeklyScheduleView = ({ user }) => {
+const WeeklyScheduleView = ({ user, onNavigate }) => {
     const [allOrders, setAllOrders] = useState([]);
     const [productionStatuses, setProductionStatuses] = useState([]);
     const [deliveryWeeks, setDeliveryWeeks] = useState([]);
@@ -142,6 +142,14 @@ const WeeklyScheduleView = ({ user }) => {
     return (
         <div>
             <div className="d-flex justify-content-end align-items-center mb-3">
+                {!isCustomer && (
+                    <button
+                        className="btn btn-info me-3"
+                        onClick={() => onNavigate('production-schedule-report')}
+                    >
+                        Production Schedule Report
+                    </button>
+                )}
                 <div className="col-md-4">
                     <select className="form-select" value={selectedWeek} onChange={(e) => setSelectedWeek(e.target.value)}>
                         <option value="">Select Delivery Week...</option>

--- a/src/pages/ProductionPage.jsx
+++ b/src/pages/ProductionPage.jsx
@@ -5,7 +5,7 @@ import OrderHistoryView from '../components/production/OrderHistoryView';
 import AllActiveOrdersView from '../components/production/AllActiveOrdersView';
 import ShippedOrdersView from '../components/production/ShippedOrdersView';
 
-const ProductionPage = ({ user }) => {
+const ProductionPage = ({ user, onNavigate }) => {
     const [activeTab, setActiveTab] = useState('schedule');
 
     return (
@@ -31,7 +31,7 @@ const ProductionPage = ({ user }) => {
                 </ul>
             </div>
             <div className="card-body">
-                {activeTab === 'schedule' && <WeeklyScheduleView user={user} />}
+                {activeTab === 'schedule' && <WeeklyScheduleView user={user} onNavigate={onNavigate} />}
                 {activeTab === 'history' && <OrderHistoryView user={user} />}
                 {activeTab === 'allActive' && user.role !== 'customer' && <AllActiveOrdersView user={user} />}
                 {activeTab === 'shipped' && user.role !== 'customer' && <ShippedOrdersView user={user} />}

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -9,13 +9,6 @@ const ReportsPage = ({ onNavigate }) => {
                 <button
                     type="button"
                     className="list-group-item list-group-item-action"
-                    onClick={() => onNavigate('production-schedule-report')}
-                >
-                    Production Schedule Report
-                </button>
-                <button
-                    type="button"
-                    className="list-group-item list-group-item-action"
                     onClick={() => onNavigate('comprehensive-report')}
                 >
                     Comprehensive Report


### PR DESCRIPTION
The "Production Schedule Report" has been moved from the main "Reports" page to the "Weekly Schedule" view on the "Production" page.

This change improves the user workflow by placing the report in a more contextually relevant location.

Changes include:
- Removing the report link from `ReportsPage.jsx`.
- Adding a new button to `WeeklyScheduleView.jsx` to open the report.
- Passing the necessary `onNavigate` prop through `App.jsx` and `ProductionPage.jsx` to enable navigation.