### PR TITLE
fix: Optimize PDF layout to prevent unnecessary page breaks

### DIFF
--- a/src/components/reports/WeeklySchedulePDF.jsx
+++ b/src/components/reports/WeeklySchedulePDF.jsx
@@ -92,8 +92,8 @@ const WeeklySchedulePDF = ({ ordersByCustomer, shippedOrders, selectedWeek }) =>
                 <Text style={styles.header}>{documentTitle}</Text>
 
                 {hasActiveOrders ? (
-                    Object.keys(ordersByCustomer).sort().map((customerName, index) => (
-                        <View key={customerName} break={index > 0}>
+                    Object.keys(ordersByCustomer).sort().map((customerName) => (
+                        <View key={customerName}>
                             <Text style={styles.customerHeader}>{customerName}</Text>
                             <View style={styles.table}>
                                 {/* Header Row */}


### PR DESCRIPTION
This commit addresses feedback on the PDF export functionality by removing the forced page break between customer sections in the weekly schedule report. This change ensures a more compact and print-friendly layout, preventing wasted space.

The `break` prop has been removed from the `<View>` component that wraps each customer's order table in `WeeklySchedulePDF.jsx`, allowing the content to flow naturally across pages.

All other functionality of the PDF export remains the same.