### PR TITLE
feat: Add content management for public pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,14 +83,20 @@ export default function App() {
     }, []);
 
     useEffect(() => {
-        let unsubUserData, unsubSettings;
+        const unsubSettings = onSnapshot(doc(db, "settings", "main"), (settingsDoc) => {
+            if (settingsDoc.exists()) {
+                setSettings(prev => ({ ...prev, ...settingsDoc.data() }));
+            }
+        });
+        return () => unsubSettings();
+    }, []);
+
+    useEffect(() => {
+        let unsubUserData;
         if (user) {
             unsubUserData = onSnapshot(doc(db, "users", user.uid), (userDoc) => {
                 const data = userDoc.data();
                 setUserData(data);
-                unsubSettings = onSnapshot(doc(db, "settings", "main"), (settingsDoc) => {
-                    if (settingsDoc.exists()) setSettings(settingsDoc.data());
-                });
                 setLoading(false);
             }, () => setLoading(false));
         } else {
@@ -99,7 +105,6 @@ export default function App() {
        
         return () => {
             if (unsubUserData) unsubUserData();
-            if (unsubSettings) unsubSettings();
         };
     }, [user]);
 
@@ -123,9 +128,9 @@ export default function App() {
         if (appStatus === 'public') {
             const publicPageMap = {
                 'home': <HomePage onLoginSuccess={() => handleNavigation('dashboard')} settings={settings} />,
-                'about': <AboutPage />,
-                'services': <ServicesPage />,
-                'contact': <ContactPage />,
+                'about': <AboutPage settings={settings} />,
+                'services': <ServicesPage settings={settings} />,
+                'contact': <ContactPage settings={settings} />,
             };
             return (
                 <div className="d-flex flex-column" style={{minHeight: '100vh'}}>

--- a/src/components/admin/ContentManagementTab.jsx
+++ b/src/components/admin/ContentManagementTab.jsx
@@ -1,0 +1,127 @@
+// src/components/admin/ContentManagementTab.jsx
+import React, { useState, useEffect } from 'react';
+import { db } from '../../firebase';
+import { doc, onSnapshot, setDoc } from "firebase/firestore";
+import toast from 'react-hot-toast';
+
+const ContentManagementTab = () => {
+    const [activeSection, setActiveSection] = useState('home');
+    const [content, setContent] = useState({
+        home: { title: '', subtitle: '' },
+        about: { text: '' },
+        services: { title: '', subtitle: '', cards: Array(4).fill({ title: '', text: '' }) },
+        contact: { text: '' }
+    });
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+
+    const docRef = doc(db, "settings", "main");
+
+    useEffect(() => {
+        const unsubscribe = onSnapshot(docRef, (doc) => {
+            if (doc.exists()) {
+                const data = doc.data();
+                const servicesData = data.servicesContent || {};
+                setContent(prev => ({
+                    home: data.homeContent || prev.home,
+                    about: data.aboutContent || prev.about,
+                    services: {
+                        title: servicesData.title || '',
+                        subtitle: servicesData.subtitle || '',
+                        cards: servicesData.cards && servicesData.cards.length === 4 ? servicesData.cards : prev.services.cards,
+                    },
+                    contact: data.contactContent || prev.contact,
+                }));
+            }
+            setLoading(false);
+        });
+        return () => unsubscribe();
+    }, []);
+
+    const handleChange = (page, field, value) => {
+        setContent(prev => ({
+            ...prev,
+            [page]: { ...prev[page], [field]: value }
+        }));
+    };
+
+    const handleServiceCardChange = (index, field, value) => {
+        setContent(prev => {
+            const newCards = [...prev.services.cards];
+            newCards[index] = { ...newCards[index], [field]: value };
+            return {
+                ...prev,
+                services: { ...prev.services, cards: newCards }
+            };
+        });
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            await setDoc(docRef, {
+                homeContent: content.home,
+                aboutContent: content.about,
+                servicesContent: content.services,
+                contactContent: content.contact,
+            }, { merge: true });
+            toast.success("Content updated successfully!");
+        } catch (error) {
+            console.error("Error saving content: ", error);
+            toast.error("Failed to update content.");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const renderSection = () => {
+        switch (activeSection) {
+            case 'home':
+                return (
+                    <>
+                        <div className="mb-3"><label htmlFor="homeTitle" className="form-label">Title</label><input id="homeTitle" type="text" className="form-control" value={content.home.title} onChange={e => handleChange('home', 'title', e.target.value)} /></div>
+                        <div className="mb-3"><label htmlFor="homeSubtitle" className="form-label">Subtitle / Slogan</label><textarea id="homeSubtitle" className="form-control" rows="3" value={content.home.subtitle} onChange={e => handleChange('home', 'subtitle', e.target.value)}></textarea></div>
+                    </>
+                );
+            case 'about':
+                return (<div className="mb-3"><label htmlFor="aboutText" className="form-label">Main Content</label><textarea id="aboutText" className="form-control" rows="8" value={content.about.text} onChange={e => handleChange('about', 'text', e.target.value)}></textarea></div>);
+            case 'services':
+                return (
+                    <>
+                        <div className="mb-3"><label htmlFor="servicesTitle" className="form-label">Main Title</label><input id="servicesTitle" type="text" className="form-control" value={content.services.title} onChange={e => handleChange('services', 'title', e.target.value)} /></div>
+                        <div className="mb-3"><label htmlFor="servicesSubtitle" className="form-label">Subtitle</label><textarea id="servicesSubtitle" className="form-control" rows="2" value={content.services.subtitle} onChange={e => handleChange('services', 'subtitle', e.target.value)}></textarea></div>
+                        <hr />
+                        <h4 className="h6 mb-3">Service Cards</h4>
+                        {content.services.cards.map((card, index) => (
+                            <div className="card mb-3" key={index}>
+                                <div className="card-body">
+                                    <h5 className="card-title mb-3">Card {index + 1}</h5>
+                                    <div className="mb-3"><label htmlFor={`serviceCardTitle${index}`} className="form-label">Card Title</label><input id={`serviceCardTitle${index}`} type="text" className="form-control" value={card.title} onChange={e => handleServiceCardChange(index, 'title', e.target.value)} /></div>
+                                    <div className="mb-3"><label htmlFor={`serviceCardText${index}`} className="form-label">Card Text</label><textarea id={`serviceCardText${index}`} className="form-control" rows="3" value={card.text} onChange={e => handleServiceCardChange(index, 'text', e.target.value)}></textarea></div>
+                                </div>
+                            </div>
+                        ))}
+                    </>
+                );
+            case 'contact':
+                return (<div className="mb-3"><label htmlFor="contactText" className="form-label">Contact Details / Address</label><textarea id="contactText" className="form-control" rows="5" value={content.contact.text} onChange={e => handleChange('contact', 'text', e.target.value)}></textarea></div>);
+            default:
+                return null;
+        }
+    };
+
+    if (loading) {
+        return <div className="text-center p-5"><div className="spinner-border" role="status"><span className="visually-hidden">Loading...</span></div></div>;
+    }
+
+    return (
+        <div>
+            <h3 className="h5 mb-4">Public Page Content</h3>
+            <ul className="nav nav-pills mb-3"><li className="nav-item"><button className={`nav-link ${activeSection === 'home' ? 'active' : ''}`} onClick={() => setActiveSection('home')}>Home Page</button></li><li className="nav-item"><button className={`nav-link ${activeSection === 'about' ? 'active' : ''}`} onClick={() => setActiveSection('about')}>About Page</button></li><li className="nav-item"><button className={`nav-link ${activeSection === 'services' ? 'active' : ''}`} onClick={() => setActiveSection('services')}>Services Page</button></li><li className="nav-item"><button className={`nav-link ${activeSection === 'contact' ? 'active' : ''}`} onClick={() => setActiveSection('contact')}>Contact Page</button></li></ul>
+            <div className="card"><div className="card-body">{renderSection()}</div></div>
+            <div className="text-end mt-4"><button onClick={handleSave} className="btn btn-primary" disabled={saving}>{saving ? <span className="spinner-border spinner-border-sm" aria-hidden="true"></span> : 'Save Content'}</button></div>
+        </div>
+    );
+};
+
+export default ContentManagementTab;

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -1,26 +1,29 @@
 // src/pages/AboutPage.jsx
 import React from 'react';
 
-const AboutPage = () => (
-    <div className="container py-5">
-        <div className="row align-items-center g-5">
-            <div className="col-lg-6">
-                <h1 className="display-5 fw-bold">The Art and Science of Sailmaking</h1>
-                <p className="lead text-muted mb-4">
-                    At Aqua Dynamics, we merge generations of traditional craftsmanship with cutting-edge technology to create sails that are not just powerful, but are extensions of the vessel and the sailor. Our passion is performance, and our promise is quality.
-                </p>
-                <p>
-                    Founded by sailors for sailors, we understand the demand for precision, durability, and speed on the water. Every sail that leaves our loft is a testament to our commitment to excellence, meticulously designed and constructed from the world's most advanced materials.
-                </p>
-                <p>
-                    Our team of master sailmakers, designers, and engineers collaborate closely with clients to deliver bespoke solutions that meet the unique demands of any vessel, from cruising yachts to competitive racing fleets.
-                </p>
-            </div>
-            <div className="col-lg-6">
-                <img src="https://images.unsplash.com/photo-1589602518993-9610531557a2?q=80&w=2070&auto=format&fit=crop" className="img-fluid rounded-3 shadow-sm" alt="Sailmaking process" />
+const AboutPage = ({ settings }) => {
+    const aboutContent = settings?.aboutContent || {};
+    const defaultText = `The Art and Science of Sailmaking...
+At Aqua Dynamics, we merge generations of traditional craftsmanship with cutting-edge technology to create sails that are not just powerful, but are extensions of the vessel and the sailor. Our passion is performance, and our promise is quality.
+
+Founded by sailors for sailors, we understand the demand for precision, durability, and speed on the water. Every sail that leaves our loft is a testament to our commitment to excellence, meticulously designed and constructed from the world's most advanced materials.
+
+Our team of master sailmakers, designers, and engineers collaborate closely with clients to deliver bespoke solutions that meet the unique demands of any vessel, from cruising yachts to competitive racing fleets.`;
+
+    return (
+        <div className="container py-5">
+            <div className="row align-items-center g-5">
+                <div className="col-lg-6">
+                    <div style={{ whiteSpace: 'pre-line' }}>
+                        {aboutContent.text || defaultText}
+                    </div>
+                </div>
+                <div className="col-lg-6">
+                    <img src="https://images.unsplash.com/photo-1589602518993-9610531557a2?q=80&w=2070&auto=format&fit=crop" className="img-fluid rounded-3 shadow-sm" alt="Sailmaking process" />
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default AboutPage;

--- a/src/pages/AdminPanel.jsx
+++ b/src/pages/AdminPanel.jsx
@@ -3,7 +3,8 @@ import React, { useState } from 'react';
 import UserManagementTab from '../components/admin/UserManagementTab';
 import CustomerManagementTab from '../components/admin/CustomerManagementTab';
 import DataManagementTab from '../components/admin/DataManagementTab';
-import MachineBreakdownTab from '../components/admin/MachineBreakdownTab'; // Import the new component
+import MachineBreakdownTab from '../components/admin/MachineBreakdownTab';
+import ContentManagementTab from '../components/admin/ContentManagementTab';
 
 const AdminPanel = () => {
     const [activeTab, setActiveTab] = useState('users');
@@ -16,8 +17,10 @@ const AdminPanel = () => {
                 return <CustomerManagementTab />;
             case 'data':
                 return <DataManagementTab />;
-            case 'machine-breakdown': // Add a case for the new tab
+            case 'machine-breakdown':
                 return <MachineBreakdownTab />;
+            case 'content':
+                return <ContentManagementTab />;
             default:
                 return <UserManagementTab />;
         }
@@ -30,7 +33,8 @@ const AdminPanel = () => {
                     <li className="nav-item"><button className={`nav-link ${activeTab === 'users' ? 'active' : ''}`} onClick={() => setActiveTab('users')}>User Management</button></li>
                     <li className="nav-item"><button className={`nav-link ${activeTab === 'customers' ? 'active' : ''}`} onClick={() => setActiveTab('customers')}>Customer Profiles</button></li>
                     <li className="nav-item"><button className={`nav-link ${activeTab === 'data' ? 'active' : ''}`} onClick={() => setActiveTab('data')}>System Data</button></li>
-                    <li className="nav-item"><button className={`nav-link ${activeTab === 'machine-breakdown' ? 'active' : ''}`} onClick={() => setActiveTab('machine-breakdown')}>Machine Breakdown</button></li> {/* Add the new tab */}
+                    <li className="nav-item"><button className={`nav-link ${activeTab === 'machine-breakdown' ? 'active' : ''}`} onClick={() => setActiveTab('machine-breakdown')}>Machine Breakdown</button></li>
+                    <li className="nav-item"><button className={`nav-link ${activeTab === 'content' ? 'active' : ''}`} onClick={() => setActiveTab('content')}>Content Management</button></li>
                  </ul>
             </div>
             <div className="card-body">

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -1,47 +1,62 @@
 // src/pages/ContactPage.jsx
 import React from 'react';
 
-const ContactPage = () => (
-    <div className="container py-5">
-        <div className="text-center mb-5">
-            <h1 className="display-5 fw-bold">Get In Touch</h1>
-            <p className="lead text-muted">We're here to help with your next project or answer any questions you may have.</p>
-        </div>
-        <div className="row g-5">
-            <div className="col-lg-6">
-                <h3 className="h4 mb-3">Contact Details</h3>
-                <p><strong>Aqua Dynamics Sail Loft</strong></p>
-                <p>123 Maritime Way,<br />Negombo, Western Province,<br />Sri Lanka</p>
-                <hr />
-                <p><strong>Phone:</strong><br /> +94 77 123 4567</p>
-                <p><strong>Email:</strong><br /> sales@aquadynamics.lk</p>
-                <hr />
-                <p><strong>Business Hours:</strong><br />Monday - Friday: 8:00 AM - 5:00 PM</p>
+const ContactPage = ({ settings }) => {
+    const contactContent = settings?.contactContent || {};
+    const defaultText = `Aqua Dynamics Sail Loft
+123 Maritime Way,
+Negombo, Western Province,
+Sri Lanka
+
+---
+**Phone:**
++94 77 123 4567
+
+**Email:**
+sales@aquadynamics.lk
+
+---
+**Business Hours:**
+Monday - Friday: 8:00 AM - 5:00 PM`;
+
+    return (
+        <div className="container py-5">
+            <div className="text-center mb-5">
+                <h1 className="display-5 fw-bold">Get In Touch</h1>
+                <p className="lead text-muted">We're here to help with your next project or answer any questions you may have.</p>
             </div>
-            <div className="col-lg-6">
-                 <h3 className="h4 mb-3">Send Us a Message</h3>
-                 <form>
-                    <div className="mb-3">
-                        <label htmlFor="contactName" className="form-label">Your Name</label>
-                        <input type="text" className="form-control" id="contactName" required />
+            <div className="row g-5">
+                <div className="col-lg-6">
+                    <h3 className="h4 mb-3">Contact Details</h3>
+                    <div style={{ whiteSpace: 'pre-line' }}>
+                        {contactContent.text || defaultText}
                     </div>
-                    <div className="mb-3">
-                        <label htmlFor="contactEmail" className="form-label">Email Address</label>
-                        <input type="email" className="form-control" id="contactEmail" required />
-                    </div>
-                     <div className="mb-3">
-                        <label htmlFor="contactSubject" className="form-label">Subject</label>
-                        <input type="text" className="form-control" id="contactSubject" required />
-                    </div>
-                    <div className="mb-3">
-                        <label htmlFor="contactMessage" className="form-label">Message</label>
-                        <textarea className="form-control" id="contactMessage" rows="5" required></textarea>
-                    </div>
-                    <button type="submit" className="btn btn-primary">Submit Message</button>
-                 </form>
+                </div>
+                <div className="col-lg-6">
+                     <h3 className="h4 mb-3">Send Us a Message</h3>
+                     <form>
+                        <div className="mb-3">
+                            <label htmlFor="contactName" className="form-label">Your Name</label>
+                            <input type="text" className="form-control" id="contactName" required />
+                        </div>
+                        <div className="mb-3">
+                            <label htmlFor="contactEmail" className="form-label">Email Address</label>
+                            <input type="email" className="form-control" id="contactEmail" required />
+                        </div>
+                         <div className="mb-3">
+                            <label htmlFor="contactSubject" className="form-label">Subject</label>
+                            <input type="text" className="form-control" id="contactSubject" required />
+                        </div>
+                        <div className="mb-3">
+                            <label htmlFor="contactMessage" className="form-label">Message</label>
+                            <textarea className="form-control" id="contactMessage" rows="5" required></textarea>
+                        </div>
+                        <button type="submit" className="btn btn-primary">Submit Message</button>
+                     </form>
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default ContactPage;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -130,14 +130,15 @@ const HomePage = ({ onLoginSuccess, settings }) => {
         );
     };
 
+    const homeContent = settings?.homeContent || {};
+
     return (
         <div className="container mt-5">
             <div className="row align-items-center g-5">
                 <div className="col-lg-7 text-center text-lg-start">
-                    <h1 className="display-4 fw-bold lh-1 mb-3">Welcome to the Aqua Dynamics Client Portal</h1>
+                    <h1 className="display-4 fw-bold lh-1 mb-3">{homeContent.title || "Welcome to the Client Portal"}</h1>
                     <p className="col-lg-10 fs-5">
-                        Manage your yacht sail orders, track production status, and view your stock levels all in one place.
-                        Access your account to get started.
+                        {homeContent.subtitle || "Manage your orders, track production, and view stock levels all in one place. Access your account to get started."}
                     </p>
                 </div>
                 <div className="col-lg-5">

--- a/src/pages/ServicesPage.jsx
+++ b/src/pages/ServicesPage.jsx
@@ -1,47 +1,38 @@
 // src/pages/ServicesPage.jsx
 import React from 'react';
 
-const ServicesPage = () => (
-    <div className="container py-5">
-        <div className="text-center mb-5">
-            <h1 className="display-5 fw-bold">Precision Marine Solutions</h1>
-            <p className="lead text-muted">From world-class custom sails to comprehensive servicing and canvas work.</p>
-        </div>
-        <div className="row g-4">
-            <div className="col-md-6 col-lg-3">
-                <div className="card h-100 text-center shadow-sm">
-                    <div className="card-body">
-                        <h3 className="h5 card-title">Custom Sail Design</h3>
-                        <p className="card-text">Collaborative design process using advanced 3D modeling to create the perfect sail for your cruising or racing needs.</p>
-                    </div>
-                </div>
+const ServicesPage = ({ settings }) => {
+    const content = settings?.servicesContent || {};
+
+    const defaultCards = [
+        { title: "Custom Sail Design", text: "Collaborative design process using advanced 3D modeling to create the perfect sail for your cruising or racing needs." },
+        { title: "Sail Manufacturing", text: "Precision manufacturing in our state-of-the-art loft, using only the highest quality materials for exceptional durability and performance." },
+        { title: "Repair & Servicing", text: "Comprehensive inspection, re-stitching, UV strip replacement, and hardware servicing to extend the life of your sails." },
+        { title: "Canvas & Accessories", text: "Custom-fit sail covers, biminis, dodgers, and other marine canvas work designed for a perfect fit and maximum protection." }
+    ];
+
+    const cards = content.cards && content.cards.length === 4 ? content.cards : defaultCards;
+
+    return (
+        <div className="container py-5">
+            <div className="text-center mb-5">
+                <h1 className="display-5 fw-bold">{content.title || "Precision Marine Solutions"}</h1>
+                <p className="lead text-muted">{content.subtitle || "From world-class custom sails to comprehensive servicing and canvas work."}</p>
             </div>
-            <div className="col-md-6 col-lg-3">
-                <div className="card h-100 text-center shadow-sm">
-                    <div className="card-body">
-                        <h3 className="h5 card-title">Sail Manufacturing</h3>
-                        <p className="card-text">Precision manufacturing in our state-of-the-art loft, using only the highest quality materials for exceptional durability and performance.</p>
+            <div className="row g-4">
+                {cards.map((card, index) => (
+                    <div className="col-md-6 col-lg-3" key={index}>
+                        <div className="card h-100 text-center shadow-sm">
+                            <div className="card-body">
+                                <h3 className="h5 card-title">{card.title}</h3>
+                                <p className="card-text">{card.text}</p>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
-            <div className="col-md-6 col-lg-3">
-                <div className="card h-100 text-center shadow-sm">
-                    <div className="card-body">
-                        <h3 className="h5 card-title">Repair & Servicing</h3>
-                        <p className="card-text">Comprehensive inspection, re-stitching, UV strip replacement, and hardware servicing to extend the life of your sails.</p>
-                    </div>
-                </div>
-            </div>
-            <div className="col-md-6 col-lg-3">
-                <div className="card h-100 text-center shadow-sm">
-                    <div className="card-body">
-                        <h3 className="h5 card-title">Canvas & Accessories</h3>
-                        <p className="card-text">Custom-fit sail covers, biminis, dodgers, and other marine canvas work designed for a perfect fit and maximum protection.</p>
-                    </div>
-                </div>
+                ))}
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default ServicesPage;


### PR DESCRIPTION
This commit introduces a new feature that allows administrators to manage the content of the public-facing pages (Home, About, Services, and Contact) from the admin panel.

Key changes include:

- A new "Content Management" tab in the admin panel provides a UI for editing page content, including titles, subtitles, and main text. The UI for the Services page preserves the original four-card layout.
- All editable content is stored in the `settings/main` document in Firestore.
- The `HomePage`, `AboutPage`, `ServicesPage`, and `ContactPage` components have been updated to dynamically render content fetched from Firestore, with fallbacks to the original hardcoded text.
- `App.jsx` has been updated to fetch the settings for all users and pass them as props to the relevant components.