### PR TITLE
feat: Add Send Ack Email button to OrderHistoryModal

### DIFF
--- a/src/components/modals/OrderHistoryModal.jsx
+++ b/src/components/modals/OrderHistoryModal.jsx
@@ -2,10 +2,12 @@
 import React, { useState, useEffect } from 'react';
 import { db } from '../../firebase';
 import { collection, query, onSnapshot, orderBy } from "firebase/firestore";
+import OrderAckEmailModal from './OrderAckEmailModal';
 
-const OrderHistoryModal = ({ order, onClose }) => {
+const OrderHistoryModal = ({ order, user, onClose }) => {
     const [history, setHistory] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [showAckModal, setShowAckModal] = useState(false);
 
     useEffect(() => {
         const historyQuery = query(collection(db, "orders", order.id, "statusHistory"), orderBy("timestamp", "desc"));
@@ -20,9 +22,16 @@ const OrderHistoryModal = ({ order, onClose }) => {
         <div className="modal fade show" style={{ display: 'block', backgroundColor: 'rgba(0,0,0,0.5)' }} tabIndex="-1">
             <div className="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
                 <div className="modal-content">
-                    <div className="modal-header">
-                        <h5 className="modal-title">History for Order: {order.aquaOrderNumber}</h5>
-                        <button type="button" className="btn-close" onClick={onClose}></button>
+                    <div className="modal-header d-flex justify-content-between align-items-center">
+                        <h5 className="modal-title mb-0">History for Order: {order.aquaOrderNumber}</h5>
+                        <div>
+                            {user && user.role !== 'customer' && (
+                                <button className="btn btn-sm btn-outline-primary me-2" onClick={() => setShowAckModal(true)}>
+                                    Send Ack Email
+                                </button>
+                            )}
+                            <button type="button" className="btn-close" onClick={onClose}></button>
+                        </div>
                     </div>
                     <div className="modal-body">
                         <p><strong>Customer:</strong> {order.customerCompanyName}</p>
@@ -59,6 +68,14 @@ const OrderHistoryModal = ({ order, onClose }) => {
                     </div>
                 </div>
             </div>
+
+            {showAckModal && (
+                <OrderAckEmailModal
+                    order={order}
+                    user={user}
+                    onClose={() => setShowAckModal(false)}
+                />
+            )}
         </div>
     );
 };

--- a/src/components/production/AllActiveOrdersView.jsx
+++ b/src/components/production/AllActiveOrdersView.jsx
@@ -249,6 +249,7 @@ const AllActiveOrdersView = ({ user }) => {
             {viewingHistoryFor && (
                 <OrderHistoryModal 
                     order={viewingHistoryFor}
+                    user={user}
                     onClose={() => setViewingHistoryFor(null)}
                 />
             )}

--- a/src/components/production/ShippedOrdersView.jsx
+++ b/src/components/production/ShippedOrdersView.jsx
@@ -191,6 +191,7 @@ const ShippedOrdersView = ({ user }) => {
             {viewingHistoryFor && (
                 <OrderHistoryModal
                     order={viewingHistoryFor}
+                    user={user}
                     onClose={() => setViewingHistoryFor(null)}
                 />
             )}

--- a/src/components/production/WeeklyScheduleView.jsx
+++ b/src/components/production/WeeklyScheduleView.jsx
@@ -276,6 +276,7 @@ const WeeklyScheduleView = ({ user }) => {
             {viewingHistoryFor && (
                 <OrderHistoryModal 
                     order={viewingHistoryFor}
+                    user={user}
                     onClose={() => setViewingHistoryFor(null)}
                 />
             )}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -145,6 +145,7 @@ const Dashboard = ({ user }) => {
              {viewingHistoryFor && (
                 <OrderHistoryModal 
                     order={viewingHistoryFor}
+                    user={user}
                     onClose={() => setViewingHistoryFor(null)}
                 />
             )}

--- a/src/pages/OrderList.jsx
+++ b/src/pages/OrderList.jsx
@@ -278,6 +278,7 @@ const OrderList = ({ user }) => {
             {viewingHistoryFor && (
                 <OrderHistoryModal 
                     order={viewingHistoryFor}
+                    user={user}
                     onClose={() => setViewingHistoryFor(null)}
                 />
             )}


### PR DESCRIPTION
Surfaces the missing email acknowledgment functionality by adding a "Send Ack Email" button directly into the `OrderHistoryModal`, which is accessible from virtually anywhere an order can be clicked (e.g., Dashboard, Weekly Schedule, All Active Orders, Order List). The button is restricted to non-customer users.

---
*PR created automatically by Jules for task [11557658718227633334](https://jules.google.com/task/11557658718227633334) started by @Aquabigbtasst5252*