### PR TITLE
fix: Update default Order Acknowledgment email template

### DIFF
--- a/src/components/modals/OrderAckEmailModal.jsx
+++ b/src/components/modals/OrderAckEmailModal.jsx
@@ -46,7 +46,8 @@ const OrderAckEmailModal = ({ order, user, onClose }) => {
                 setSubject(generatedSubject);
 
                 // Generate Body
-                let template = settings.orderAckEmailBody || '';
+                const defaultTemplate = `Dear {{CustomerName}},\nWe acknowledge receipt of your purchase order {{PONumber}} dated {{OrderDate}}.\nThe order is currently under review. A separate confirmation with estimated production end dates will follow shortly.\nIf any clarification is required in the meantime, we will contact you directly. Best Regards Yacht Sails Team`;
+                let template = settings.orderAckEmailBody || defaultTemplate;
                 const orderDate = order.createdAt?.toDate ? order.createdAt.toDate().toLocaleDateString() : 'N/A';
                 const orderDescription = `${order.productName} - ${order.material}`;
 


### PR DESCRIPTION
Updates the fallback `defaultTemplate` in `OrderAckEmailModal` to match the exact text requested by the user, incorporating the proper Handlebars-style placeholders (`{{CustomerName}}`, `{{PONumber}}`, `{{OrderDate}}`) that the component's replacement logic expects. This ensures that even if custom settings are not defined in Firestore, the email will have the correct, formatted content.