### PR TITLE
fix: Set CC email to chamal@aquadynamics.lk for all outbound emails

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -72,10 +72,7 @@ Yacht sail team.`;
                 from: `"Aqua Dynamics" <${gmailEmail.value()}>`,
                 to: recipientEmail,
                 cc: [
-                    "chamal@aquadynamics.lk",
-                    "bandu@aquadynamics.lk",
-                    "prasannaw@aquadynamics.lk",
-                    "udana@aquadynamics.lk"
+                    "chamal@aquadynamics.lk"
                 ],
                 subject: subject,
                 text: body,
@@ -128,10 +125,7 @@ exports.sendOrderAckEmail = onCall(async (request) => {
                 from: `"Aqua Dynamics" <${gmailEmail.value()}>`,
                 to: recipientEmails,
                 cc: [
-                    "chamal@aquadynamics.lk",
-                    "bandu@aquadynamics.lk",
-                    "prasannaw@aquadynamics.lk",
-                    "udana@aquadynamics.lk"
+                    "chamal@aquadynamics.lk"
                 ],
                 subject: subject,
                 text: body,


### PR DESCRIPTION
Updates the `sendQcPhotoEmail` and `sendOrderAckEmail` Cloud Functions to ensure that `chamal@aquadynamics.lk` is the only email address CC'd when these automated emails are sent, fulfilling the explicit user request.