### PR TITLE
Fix missing user auth causing Firestore permission-denied errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,36 +57,27 @@ export default function App() {
     }, []);
 
     useEffect(() => {
-        // Mock user
-        setUser({ uid: "mockUser123", email: "admin@test.com", displayName: "Admin User" });
-        setUserData({
-            name: "Admin User",
-            email: "admin@test.com",
-            role: "super_admin",
-            status: "active"
+        const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+            if (currentUser && !currentUser.isAnonymous) {
+                setUser(currentUser);
+                const userDocRef = doc(db, "users", currentUser.uid);
+                const docSnap = await getDoc(userDocRef);
+                if (!docSnap.exists()) {
+                    await setDoc(userDocRef, {
+                        email: currentUser.email,
+                        name: currentUser.displayName || 'New User',
+                        role: 'customer',
+                        status: 'pending',
+                        createdAt: serverTimestamp()
+                    });
+                }
+            } else {
+                setUser(null);
+                setUserData(null);
+                setLoading(false);
+            }
         });
-        setLoading(false);
-        // const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
-        //     if (currentUser && !currentUser.isAnonymous) {
-        //         setUser(currentUser);
-        //         const userDocRef = doc(db, "users", currentUser.uid);
-        //         const docSnap = await getDoc(userDocRef);
-        //         if (!docSnap.exists()) {
-        //             await setDoc(userDocRef, {
-        //                 email: currentUser.email,
-        //                 name: currentUser.displayName || 'New User',
-        //                 role: 'customer',
-        //                 status: 'pending',
-        //                 createdAt: serverTimestamp()
-        //             });
-        //         }
-        //     } else {
-        //         setUser(null);
-        //         setUserData(null);
-        //         setLoading(false);
-        //     }
-        // });
-        // return () => unsubscribe();
+        return () => unsubscribe();
     }, []);
 
     useEffect(() => {
@@ -94,26 +85,31 @@ export default function App() {
             if (settingsDoc.exists()) {
                 setSettings(prev => ({ ...prev, ...settingsDoc.data() }));
             }
+        }, (error) => {
+            console.error("Error fetching settings:", error);
         });
         return () => unsubSettings();
     }, []);
 
-    // useEffect(() => {
-    //     let unsubUserData;
-    //     if (user) {
-    //         unsubUserData = onSnapshot(doc(db, "users", user.uid), (userDoc) => {
-    //             const data = userDoc.data();
-    //             setUserData(data);
-    //             setLoading(false);
-    //         }, () => setLoading(false));
-    //     } else {
-    //         setLoading(false);
-    //     }
+    useEffect(() => {
+        let unsubUserData;
+        if (user) {
+            unsubUserData = onSnapshot(doc(db, "users", user.uid), (userDoc) => {
+                const data = userDoc.data();
+                setUserData(data);
+                setLoading(false);
+            }, (error) => {
+                console.error("Error fetching user data:", error);
+                setLoading(false);
+            });
+        } else {
+            setLoading(false);
+        }
        
-    //     return () => {
-    //         if (unsubUserData) unsubUserData();
-    //     };
-    // }, [user]);
+        return () => {
+            if (unsubUserData) unsubUserData();
+        };
+    }, [user]);
 
     const appStatus = useMemo(() => {
         if (loading) return 'loading';


### PR DESCRIPTION
Fix missing user auth causing Firestore permission-denied errors

Reverts a mock user workaround in `App.jsx` that set the user state directly without properly authenticating the Firebase SDK. This resulted in `auth.currentUser` being null, which caused all Firestore `onSnapshot` queries to fail silently with a `permission-denied` error (since `firestore.rules` requires `request.auth != null`). Also, added explicit error handling to the `onSnapshot` listeners in `App.jsx` and `Dashboard.jsx` to prevent silent infinite loading hangs on future errors.

---
*PR created automatically by Jules for task [6382672085784841150](https://jules.google.com/task/6382672085784841150) started by @Aquabigbtasst5252*