### PR TITLE
Fix CORS policy error in sendOrderAckEmail Cloud Function

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,10 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,14 +13,19 @@ const gmailEmail = defineString("GMAIL_EMAIL");
 const gmailPassword = defineString("GMAIL_PASSWORD");
 const appUrl = defineString("APP_URL");
 
-const mailTransport = nodemailer.createTransport({
-    service: "gmail",
-    auth: {
-        // Use .value() to access the secret
-        user: gmailEmail.value(),
-        pass: gmailPassword.value(),
-    },
-});
+let mailTransport = null;
+const getMailTransport = () => {
+    if (!mailTransport) {
+        mailTransport = nodemailer.createTransport({
+            service: "gmail",
+            auth: {
+                user: gmailEmail.value(),
+                pass: gmailPassword.value(),
+            },
+        });
+    }
+    return mailTransport;
+};
 
 exports.sendQcPhotoEmail = onDocumentCreated("orders/{orderId}/qcPhotos/{photoId}", async (event) => {
     const orderId = event.params.orderId;
@@ -78,7 +83,7 @@ Yacht sail team.`;
                 text: body,
             };
 
-            await mailTransport.sendMail(mailOptions);
+            await getMailTransport().sendMail(mailOptions);
             logger.log(`QC email sent successfully to ${recipientEmail} for order ${orderData.aquaOrderNumber}`);
 
             transaction.update(orderRef, { qcEmailSent: true });
@@ -88,7 +93,7 @@ Yacht sail team.`;
     }
 });
 
-exports.sendOrderAckEmail = onCall(async (request) => {
+exports.sendOrderAckEmail = onCall({ cors: true }, async (request) => {
     const { orderId, toEmails, subject, body, sentBy } = request.data;
 
     // Check authentication
@@ -131,7 +136,7 @@ exports.sendOrderAckEmail = onCall(async (request) => {
                 text: body,
             };
 
-            await mailTransport.sendMail(mailOptions);
+            await getMailTransport().sendMail(mailOptions);
             logger.log(`Order Acknowledgment email sent successfully to ${recipientEmails.join(', ')} for order ${orderId}`);
 
             transaction.update(orderRef, {


### PR DESCRIPTION
Fixes an issue where `sendOrderAckEmail` failed with a CORS policy error. In Firebase Cloud Functions v2, accessing secrets via `.value()` at the global scope causes the function to crash on initialization, which prevents it from responding to CORS `OPTIONS` preflight requests. The `nodemailer` transport has been moved inside a getter function so it's only instantiated at runtime.

---
*PR created automatically by Jules for task [12571793512652187154](https://jules.google.com/task/12571793512652187154) started by @Aquabigbtasst5252*