### PR TITLE
fix: remove explicit cors configuration from onCall trigger

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -93,7 +93,7 @@ Yacht sail team.`;
     }
 });
 
-exports.sendOrderAckEmail = onCall({ cors: true }, async (request) => {
+exports.sendOrderAckEmail = onCall(async (request) => {
     const { orderId, toEmails, subject, body, sentBy } = request.data;
 
     // Check authentication


### PR DESCRIPTION
- In Firebase Cloud Functions v2, `onCall` handles CORS out of the box. Explicitly passing `{ cors: true }` can sometimes interfere with this and cause CORS preflight failures or `internal` errors when called from certain origins.
- Removed the `{ cors: true }` property from `sendOrderAckEmail` to rely on the default v2 onCall CORS handling.