### PR TITLE
fix: Handle explicit CORS configuration for sendOrderAckEmail

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -93,7 +93,7 @@ Yacht sail team.`;
     }
 });
 
-exports.sendOrderAckEmail = onCall(async (request) => {
+exports.sendOrderAckEmail = onCall({ cors: true }, async (request) => {
     const { orderId, toEmails, subject, body, sentBy } = request.data;
 
     // Check authentication


### PR DESCRIPTION
- Restored explicit `{ cors: true }` parameter in `onCall` configuration.
- Diagnosed that `defineString` behaves properly without crashing if the `.env` value is missing, provided `.value()` is not invoked globally.
- Explicitly setting `cors: true` helps ensure permissive CORS headers are attached, while keeping `.value()` execution lazy prevents cold-start crashes.
- This ensures Firebase Cloud Functions v2 can properly handle cross-origin preflight `OPTIONS` requests from the Vercel frontend without dropping them due to internal server errors.