### PR TITLE
fix: Refactor sendOrderAckEmail to onRequest with explicit CORS handling

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,9 +1,15 @@
 const { onDocumentCreated } = require("firebase-functions/v2/firestore");
-const { onCall, HttpsError } = require("firebase-functions/v2/https");
+const { onRequest, HttpsError } = require("firebase-functions/v2/https");
 const { logger } = require("firebase-functions");
 const { defineString } = require("firebase-functions/params"); // Import defineString
 const admin = require("firebase-admin");
 const nodemailer = require("nodemailer");
+const cors = require("cors")({
+    origin: [
+        "https://yacht-sail-order-recorder-vercel.vercel.app",
+        "http://localhost:5173" // allow local development as well
+    ]
+});
 
 admin.initializeApp();
 const db = admin.firestore();
@@ -93,62 +99,81 @@ Yacht sail team.`;
     }
 });
 
-exports.sendOrderAckEmail = onCall({ cors: true }, async (request) => {
-    const { orderId, toEmails, subject, body, sentBy } = request.data;
+exports.sendOrderAckEmail = onRequest((req, res) => {
+    cors(req, res, async () => {
+        if (req.method === "OPTIONS") {
+            return res.status(204).send("");
+        }
 
-    // Check authentication
-    if (!request.auth) {
-        throw new HttpsError('unauthenticated', 'User must be authenticated to send emails.');
-    }
+        try {
+            // Since this replaces onCall, we must extract data from req.body.data
+            // The client SDK sends data wrapped in a "data" object.
+            const payload = req.body.data || {};
+            const { orderId, toEmails, subject, body, sentBy } = payload;
 
-    if (!orderId || !toEmails || !subject || !body) {
-        throw new HttpsError('invalid-argument', 'Missing required fields.');
-    }
-
-    logger.info(`Starting Order Acknowledgment email process for order: ${orderId}`);
-
-    try {
-        const orderRef = db.collection("orders").doc(orderId);
-
-        await db.runTransaction(async (transaction) => {
-            const orderDoc = await transaction.get(orderRef);
-            if (!orderDoc.exists) {
-                throw new HttpsError('not-found', `Order ${orderId} does not exist.`);
+            // Verify Auth via Authorization header
+            const authHeader = req.headers.authorization;
+            if (!authHeader || !authHeader.startsWith("Bearer ")) {
+                return res.status(401).json({ error: { message: "User must be authenticated to send emails.", status: "UNAUTHENTICATED" } });
+            }
+            const idToken = authHeader.split("Bearer ")[1];
+            let decodedToken;
+            try {
+                decodedToken = await admin.auth().verifyIdToken(idToken);
+            } catch {
+                return res.status(401).json({ error: { message: "Invalid authentication token.", status: "UNAUTHENTICATED" } });
             }
 
-            const orderData = orderDoc.data();
-            if (orderData.orderAckEmailSent) {
-                logger.warn(`Order Acknowledgment email already sent for order ${orderId}. Allowing resend, but updating timestamp.`);
+            if (!orderId || !toEmails || !subject || !body) {
+                return res.status(400).json({ error: { message: "Missing required fields.", status: "INVALID_ARGUMENT" } });
             }
 
-            const recipientEmails = toEmails.split(',').map(e => e.trim()).filter(e => e);
-            if (recipientEmails.length === 0) {
-                throw new HttpsError('invalid-argument', 'No valid email addresses provided.');
-            }
+            logger.info(`Starting Order Acknowledgment email process for order: ${orderId}`);
 
-            const mailOptions = {
-                from: `"Aqua Dynamics" <${gmailEmail.value()}>`,
-                to: recipientEmails,
-                cc: [
-                    "chamal@aquadynamics.lk"
-                ],
-                subject: subject,
-                text: body,
-            };
+            const orderRef = db.collection("orders").doc(orderId);
 
-            await getMailTransport().sendMail(mailOptions);
-            logger.log(`Order Acknowledgment email sent successfully to ${recipientEmails.join(', ')} for order ${orderId}`);
+            await db.runTransaction(async (transaction) => {
+                const orderDoc = await transaction.get(orderRef);
+                if (!orderDoc.exists) {
+                    throw new Error(`Order ${orderId} does not exist.`);
+                }
 
-            transaction.update(orderRef, {
-                orderAckEmailSent: true,
-                orderAckEmailSentAt: admin.firestore.FieldValue.serverTimestamp(),
-                orderAckEmailSentBy: sentBy || request.auth.token.name || 'Unknown User'
+                const orderData = orderDoc.data();
+                if (orderData.orderAckEmailSent) {
+                    logger.warn(`Order Acknowledgment email already sent for order ${orderId}. Allowing resend, but updating timestamp.`);
+                }
+
+                const recipientEmails = toEmails.split(',').map(e => e.trim()).filter(e => e);
+                if (recipientEmails.length === 0) {
+                    throw new Error('No valid email addresses provided.');
+                }
+
+                const mailOptions = {
+                    from: `"Aqua Dynamics" <${gmailEmail.value()}>`,
+                    to: recipientEmails,
+                    cc: [
+                        "chamal@aquadynamics.lk"
+                    ],
+                    subject: subject,
+                    text: body,
+                };
+
+                await getMailTransport().sendMail(mailOptions);
+                logger.log(`Order Acknowledgment email sent successfully to ${recipientEmails.join(', ')} for order ${orderId}`);
+
+                transaction.update(orderRef, {
+                    orderAckEmailSent: true,
+                    orderAckEmailSentAt: admin.firestore.FieldValue.serverTimestamp(),
+                    orderAckEmailSentBy: sentBy || decodedToken.name || 'Unknown User'
+                });
             });
-        });
 
-        return { success: true, message: 'Email sent successfully.' };
-    } catch (error) {
-        logger.error(`Failed to send Order Acknowledgment email for order ${orderId}:`, error);
-        throw new HttpsError('internal', `Failed to send email: ${error.message}`);
-    }
+            // For httpsCallable, return response in { data: ... }
+            return res.status(200).json({ data: { success: true, message: 'Email sent successfully.' } });
+        } catch (error) {
+            logger.error(`Failed to send Order Acknowledgment email:`, error);
+            // The Firebase client expects errors inside an "error" object
+            return res.status(500).json({ error: { message: `Failed to send email: ${error.message}`, status: "INTERNAL" } });
+        }
+    });
 });

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "cors": "^2.8.6",
         "firebase-admin": "^11.0.0",
         "firebase-functions": "^6.4.0",
         "nodemailer": "^7.0.6"
@@ -1146,9 +1147,9 @@
       "license": "MIT"
     },
     "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -1156,6 +1157,10 @@
       },
       "engines": {
         "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,6 +11,7 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
+    "cors": "^2.8.6",
     "firebase-admin": "^11.0.0",
     "firebase-functions": "^6.4.0",
     "nodemailer": "^7.0.6"


### PR DESCRIPTION
- Replaced `onCall` with `onRequest` for `sendOrderAckEmail` to fully control CORS behavior.
- Integrated the `cors` package to explicitly allow `https://yacht-sail-order-recorder-vercel.vercel.app` and `localhost` origins, directly addressing the preflight request failures.
- Manually implemented the `httpsCallable` protocol so the frontend client SDK doesn't break, extracting parameters from `req.body.data` and formatting successful responses inside `{ data: ... }`.
- Added manual Authorization header parsing and `admin.auth().verifyIdToken` to ensure the endpoint remains secure, mirroring the `request.auth` capabilities of `onCall`.