### PR TITLE
feat: allow admins to delete users and reset passwords

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -177,3 +177,93 @@ exports.sendOrderAckEmail = onRequest((req, res) => {
         }
     });
 });
+exports.adminDeleteUser = onRequest((req, res) => {
+    cors(req, res, async () => {
+        if (req.method === "OPTIONS") {
+            return res.status(204).send("");
+        }
+        try {
+            const payload = req.body.data || {};
+            const { userId } = payload;
+
+            const authHeader = req.headers.authorization;
+            if (!authHeader || !authHeader.startsWith("Bearer ")) {
+                return res.status(401).json({ error: { message: "User must be authenticated.", status: "UNAUTHENTICATED" } });
+            }
+            const idToken = authHeader.split("Bearer ")[1];
+            let decodedToken;
+            try {
+                decodedToken = await admin.auth().verifyIdToken(idToken);
+            } catch {
+                return res.status(401).json({ error: { message: "Invalid authentication token.", status: "UNAUTHENTICATED" } });
+            }
+
+            const callerDoc = await db.collection("users").doc(decodedToken.uid).get();
+            if (!callerDoc.exists) {
+                return res.status(403).json({ error: { message: "User document not found.", status: "PERMISSION_DENIED" } });
+            }
+            const callerData = callerDoc.data();
+            if (callerData.role !== 'admin' && callerData.role !== 'super_admin') {
+                return res.status(403).json({ error: { message: "Must be admin to perform this action.", status: "PERMISSION_DENIED" } });
+            }
+
+            if (!userId) {
+                return res.status(400).json({ error: { message: "Missing required fields.", status: "INVALID_ARGUMENT" } });
+            }
+
+            await admin.auth().deleteUser(userId);
+            await db.collection("users").doc(userId).delete();
+
+            return res.status(200).json({ data: { success: true, message: 'User deleted successfully.' } });
+
+        } catch (error) {
+            logger.error(`Failed to delete user:`, error);
+            return res.status(500).json({ error: { message: error.message, status: "INTERNAL" } });
+        }
+    });
+});
+
+exports.adminUpdateUserPassword = onRequest((req, res) => {
+    cors(req, res, async () => {
+        if (req.method === "OPTIONS") {
+            return res.status(204).send("");
+        }
+        try {
+            const payload = req.body.data || {};
+            const { userId, newPassword } = payload;
+
+            const authHeader = req.headers.authorization;
+            if (!authHeader || !authHeader.startsWith("Bearer ")) {
+                return res.status(401).json({ error: { message: "User must be authenticated.", status: "UNAUTHENTICATED" } });
+            }
+            const idToken = authHeader.split("Bearer ")[1];
+            let decodedToken;
+            try {
+                decodedToken = await admin.auth().verifyIdToken(idToken);
+            } catch {
+                return res.status(401).json({ error: { message: "Invalid authentication token.", status: "UNAUTHENTICATED" } });
+            }
+
+            const callerDoc = await db.collection("users").doc(decodedToken.uid).get();
+            if (!callerDoc.exists) {
+                return res.status(403).json({ error: { message: "User document not found.", status: "PERMISSION_DENIED" } });
+            }
+            const callerData = callerDoc.data();
+            if (callerData.role !== 'admin' && callerData.role !== 'super_admin') {
+                return res.status(403).json({ error: { message: "Must be admin to perform this action.", status: "PERMISSION_DENIED" } });
+            }
+
+            if (!userId || !newPassword) {
+                return res.status(400).json({ error: { message: "Missing required fields.", status: "INVALID_ARGUMENT" } });
+            }
+
+            await admin.auth().updateUser(userId, { password: newPassword });
+
+            return res.status(200).json({ data: { success: true, message: 'Password updated successfully.' } });
+
+        } catch (error) {
+            logger.error(`Failed to update password:`, error);
+            return res.status(500).json({ error: { message: error.message, status: "INTERNAL" } });
+        }
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
-        "@eslint/js": "^9.33.0",
+        "@eslint/js": "^9.39.5",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6279,6 +6279,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
+      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
-    "@eslint/js": "^9.33.0",
+    "@eslint/js": "^9.39.5",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/src/components/admin/UserManagementTab.jsx
+++ b/src/components/admin/UserManagementTab.jsx
@@ -1,13 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
-import { db } from '../../firebase';
-import { collection, onSnapshot, doc, updateDoc, deleteDoc } from 'firebase/firestore';
+import { db, functions, auth } from '../../firebase';
+import { collection, onSnapshot, doc, updateDoc } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
 
 const UserManagementTab = () => {
     const [users, setUsers] = useState([]);
     const [customers, setCustomers] = useState([]);
     const [editingUserId, setEditingUserId] = useState(null);
     const [editName, setEditName] = useState('');
+    const [changingPasswordUserId, setChangingPasswordUserId] = useState(null);
+    const [newPassword, setNewPassword] = useState('');
+    const [isActionLoading, setIsActionLoading] = useState(false);
     
     useEffect(() => { 
         const unsubUsers = onSnapshot(collection(db, "users"), (snapshot) => setUsers(snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }))));
@@ -51,7 +55,7 @@ const UserManagementTab = () => {
     };
 
     const confirmDeleteUser = (userId, userName) => {
-        const warning = "This only deletes application data, not their login account.";
+        const warning = "This permanently deletes application data and their login account.";
         toast((t) => (
             <div className="d-flex flex-column p-2">
                 <p className="fw-bold text-center">Delete {userName}?</p>
@@ -59,6 +63,7 @@ const UserManagementTab = () => {
                 <div className="d-flex justify-content-center gap-2 mt-2">
                     <button 
                         className="btn btn-sm btn-danger" 
+                        disabled={isActionLoading}
                         onClick={() => {
                             handleDeleteUser(userId);
                             toast.dismiss(t.id);
@@ -78,12 +83,54 @@ const UserManagementTab = () => {
     };
 
     const handleDeleteUser = async (userId) => {
+        if (!auth.currentUser) {
+            toast.error("You must be logged in.");
+            return;
+        }
+        setIsActionLoading(true);
         try {
-            await deleteDoc(doc(db, "users", userId));
+            const deleteUserFn = httpsCallable(functions, 'adminDeleteUser');
+            await deleteUserFn({ userId });
             toast.success('User data deleted successfully.');
         } catch (error) {
             console.error("Error deleting user data: ", error);
-            toast.error('Failed to delete user data.');
+            toast.error(`Failed to delete user data: ${error.message}`);
+        } finally {
+            setIsActionLoading(false);
+        }
+    };
+
+    const handleChangePasswordClick = (user) => {
+        setChangingPasswordUserId(user.id);
+        setNewPassword('');
+    };
+
+    const handleCancelPasswordClick = () => {
+        setChangingPasswordUserId(null);
+        setNewPassword('');
+    };
+
+    const handleSavePasswordClick = async () => {
+        if (!newPassword.trim() || newPassword.length < 6) {
+            toast.error("Password must be at least 6 characters long.");
+            return;
+        }
+        if (!auth.currentUser) {
+            toast.error("You must be logged in.");
+            return;
+        }
+        setIsActionLoading(true);
+        try {
+            const updatePasswordFn = httpsCallable(functions, 'adminUpdateUserPassword');
+            await updatePasswordFn({ userId: changingPasswordUserId, newPassword });
+            toast.success("Password updated successfully.");
+            setChangingPasswordUserId(null);
+            setNewPassword('');
+        } catch (error) {
+            console.error("Error updating password:", error);
+            toast.error(`Failed to update password: ${error.message}`);
+        } finally {
+            setIsActionLoading(false);
         }
     };
 
@@ -156,13 +203,28 @@ const UserManagementTab = () => {
                              <td>
                                 {editingUserId === u.id ? (
                                     <>
-                                        <button className="btn btn-sm btn-success me-2" onClick={handleSaveClick}>Save</button>
-                                        <button className="btn btn-sm btn-secondary" onClick={handleCancelClick}>Cancel</button>
+                                        <button className="btn btn-sm btn-success me-2" onClick={handleSaveClick} disabled={isActionLoading}>Save</button>
+                                        <button className="btn btn-sm btn-secondary" onClick={handleCancelClick} disabled={isActionLoading}>Cancel</button>
                                     </>
+                                ) : changingPasswordUserId === u.id ? (
+                                    <div className="d-flex align-items-center">
+                                        <input
+                                            type="text"
+                                            className="form-control form-control-sm me-2"
+                                            placeholder="New Password"
+                                            value={newPassword}
+                                            onChange={(e) => setNewPassword(e.target.value)}
+                                            style={{width: '120px'}}
+                                            disabled={isActionLoading}
+                                        />
+                                        <button className="btn btn-sm btn-success me-1" onClick={handleSavePasswordClick} disabled={isActionLoading}>Save</button>
+                                        <button className="btn btn-sm btn-secondary" onClick={handleCancelPasswordClick} disabled={isActionLoading}>Cancel</button>
+                                    </div>
                                 ) : (
                                     <>
-                                    <button className="btn btn-sm btn-outline-primary me-2" onClick={() => handleEditClick(u)}>Edit Name</button>
-                                    <button className="btn btn-sm btn-outline-danger" onClick={() => confirmDeleteUser(u.id, u.name)}>Delete</button>
+                                    <button className="btn btn-sm btn-outline-primary me-2" onClick={() => handleEditClick(u)} disabled={isActionLoading}>Edit Name</button>
+                                    <button className="btn btn-sm btn-outline-warning me-2" onClick={() => handleChangePasswordClick(u)} disabled={isActionLoading}>Reset Pwd</button>
+                                    <button className="btn btn-sm btn-outline-danger" onClick={() => confirmDeleteUser(u.id, u.name)} disabled={isActionLoading}>Delete</button>
                                     </>
                                 )}
                             </td>


### PR DESCRIPTION
This change implements the user's request to have an option to completely delete a user and change passwords from the admin portal, solving issues relying solely on client-side functions.

---
*PR created automatically by Jules for task [9816931029344895882](https://jules.google.com/task/9816931029344895882) started by @Aquabigbtasst5252*